### PR TITLE
Added filter to hide past days from index page

### DIFF
--- a/app/Http/Controllers/DayController.php
+++ b/app/Http/Controllers/DayController.php
@@ -16,7 +16,11 @@ class DayController extends Controller
      */
     public function index(Request $request)
     {
-        $days = Day::query()->withCount('tables')->orderBy('date', 'desc')->get();
+        $days = Day::query()
+                ->withCount('tables')
+                ->where('date', '>=', now()->format('Y-m-d'))
+                ->orderBy('date', 'desc')
+                ->get();
 
         return view('day.index', compact('days'));
     }

--- a/tests/Feature/Http/Controllers/DayControllerTest.php
+++ b/tests/Feature/Http/Controllers/DayControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Day;
+
 test('The index page is rendered correctly', function () {
     $this->seed();
     $this->actingAs(\App\Models\User::first());
@@ -64,4 +66,19 @@ test('A day is created successfully', function () {
         ->and([
             'date' => $date
         ])->toBeInDatabase(table: 'days');
+});
+
+test('The past days are hidden from index page', function () {
+    $this->seed();
+    $this->actingAs(\App\Models\User::first());
+
+    $pastDay = Day::factory()->create([
+        'date' => now()->sub('day', 1),
+    ]);
+
+    $response = $this->get(route('days.index'));
+
+    expect($response)
+    ->toBeOk()
+    ->not->toContainText($pastDay->date->format('d/m/Y'));
 });


### PR DESCRIPTION
Now on the days index page, only the current and future days are visible on the index page