### PR TITLE
Added max players number verification on user subscription

### DIFF
--- a/database/factories/TableFactory.php
+++ b/database/factories/TableFactory.php
@@ -24,7 +24,7 @@ class TableFactory extends Factory
     public function definition()
     {
         return [
-            'players_number' => $this->faker->numberBetween(1, 10),
+            'players_number' => 2,
             'total_points' => $this->faker->numberBetween(1000, 3000),
             'start_hour' => $this->faker->time,
         ];


### PR DESCRIPTION
A user could not be subscribed to a table if the maximum number of players is reached