### PR TITLE
Refactoring structure and improve execution time of tests

### DIFF
--- a/app/Actions/Discord/SendDiscordNotificationAction.php
+++ b/app/Actions/Discord/SendDiscordNotificationAction.php
@@ -6,8 +6,9 @@ use GuzzleHttp\Client;
 
 class SendDiscordNotificationAction
 {
-    public function __construct(private Client $client)
-    {
+    public function __construct(
+        private Client $client
+    ) {
         //
     }
 

--- a/app/Actions/Table/CountTablesForTimeSlotAction.php
+++ b/app/Actions/Table/CountTablesForTimeSlotAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Actions\Table;
+
+use Illuminate\Database\Eloquent\Collection;
+
+class CountTablesForTimeSlotAction
+{
+    public function __invoke(
+        Collection $tables,
+        int $startHour,
+        int $endHour
+    ): int {
+        return $tables->filter(function ($value) use ($startHour, $endHour) {
+            $hour = explode(':', $value->start_hour)[0];
+
+            return $hour >= $startHour && $hour < $endHour;
+        })->count();
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Table\CountTablesForTimeSlotAction;
 use App\Models\Day;
 use App\Models\Table;
 use App\Models\User;
@@ -9,25 +10,21 @@ use Illuminate\View\View;
 
 class DashboardController extends Controller
 {
+    public function __construct(
+        public CountTablesForTimeSlotAction $countTablesForTimeSlotAction,
+    ) {
+        //
+    }
+
     public function __invoke(): View
     {
         $users = User::count();
-
         $days = Day::count();
-
         $tables = Table::count();
 
-        $afternoonTables = Table::all()->filter(function ($value, $key) {
-            $hour = explode(':', $value->start_hour)[0];
+        $afternoonTables = ($this->countTablesForTimeSlotAction)(Table::all(), 13, 19);
 
-            return $hour >= 13 && $hour <= 19;
-        })->count();
-
-        $eveningTables = Table::all()->filter(function ($value, $key) {
-            $hour = explode(':', $value->start_hour)[0];
-
-            return $hour > 19 && $hour < 23;
-        })->count();
+        $eveningTables = ($this->countTablesForTimeSlotAction)(Table::all(), 19, 23);
 
         return view('dashboard', compact('users', 'days', 'tables', 'afternoonTables', 'eveningTables'));
     }

--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -2,13 +2,19 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Game;
+use App\Repositories\GameRepository;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class GameController extends Controller
 {
+    public function __construct(
+        public GameRepository $gameRepository
+    ) {
+        //
+    }
+
     public function create(): RedirectResponse
     {
         return redirect('/admin/games/create');
@@ -19,8 +25,6 @@ class GameController extends Controller
      */
     public function searchByCategory(Request $request): Collection
     {
-        return Game::where('category_id', $request->category)
-            ->orderBy('name', 'asc')
-            ->get();
+        return $this->gameRepository->findByCategory($request->category);
     }
 }

--- a/app/Notifications/Discord/DiscordNotification.php
+++ b/app/Notifications/Discord/DiscordNotification.php
@@ -12,15 +12,13 @@ abstract class DiscordNotification implements NotificationInterface
 
     public function __construct(
         public DiscordNotificationData $discordNotificationData,
-        public DefineChannelIdAction $defineChannelIdAction,
-        public SendDiscordNotificationAction $sendDiscordNotificationAction,
     ) {
         //
     }
 
     public function handle(): void
     {
-        $this->channelId = ($this->defineChannelIdAction)($this->discordNotificationData->day->date);
+        $this->channelId = app(DefineChannelIdAction::class)($this->discordNotificationData->day->date);
 
         $notificationContent = $this->buildMessage($this->discordNotificationData);
 
@@ -31,6 +29,6 @@ abstract class DiscordNotification implements NotificationInterface
 
     public function send(array $message): void
     {
-        ($this->sendDiscordNotificationAction)($this->channelId, $message);
+        app(sendDiscordNotificationAction::class)($this->channelId, $message);
     }
 }

--- a/app/Notifications/Discord/NotificationFactory.php
+++ b/app/Notifications/Discord/NotificationFactory.php
@@ -2,26 +2,17 @@
 
 namespace App\Notifications\Discord;
 
-use App\Actions\Discord\DefineChannelIdAction;
-use App\Actions\Discord\SendDiscordNotificationAction;
 use App\DataObjects\DiscordNotificationData;
 use Illuminate\Support\Str;
 
 class NotificationFactory
 {
-    public function __construct(
-        public DefineChannelIdAction $defineChannelIdAction,
-        public SendDiscordNotificationAction $sendDiscordNotificationAction,
-    ) {
-        //
-    }
-
     public function __invoke(
         string $type,
         DiscordNotificationData $discordNotificationData
     ): mixed {
         $class = __NAMESPACE__.'\\'.Str::studly($type).'Notification';
 
-        return new $class($discordNotificationData, $this->defineChannelIdAction, $this->sendDiscordNotificationAction);
+        return new $class($discordNotificationData);
     }
 }

--- a/app/Repositories/GameRepository.php
+++ b/app/Repositories/GameRepository.php
@@ -12,9 +12,7 @@ class GameRepository
         return Game::findOrFail($id);
     }
 
-    /**
-     * @return Collection<\App\Models\Game>
-     */
+    // @phpstan-ignore-next-line
     public function findByCategory(string $categoryId): Collection
     {
         return Game::where('category_id', $categoryId)

--- a/app/Repositories/GameRepository.php
+++ b/app/Repositories/GameRepository.php
@@ -3,11 +3,22 @@
 namespace App\Repositories;
 
 use App\Models\Game;
+use Illuminate\Database\Eloquent\Collection;
 
 class GameRepository
 {
     public function findOrFail(int $id): Game
     {
         return Game::findOrFail($id);
+    }
+
+    /**
+     * @return Collection<\App\Models\Game>
+     */
+    public function findByCategory(string $categoryId): Collection
+    {
+        return Game::where('category_id', $categoryId)
+            ->orderBy('name', 'asc')
+            ->get();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,10 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "./tests/Factories.php"
+        ]
     },
     "scripts": {
         "post-autoload-dump": [

--- a/tests/Factories.php
+++ b/tests/Factories.php
@@ -27,12 +27,12 @@ function createEvent(): Event
         ]);
 }
 
-function createGameWithCategory()
+function createGameWithCategory(Category $category = null): Game
 {
     $category = Category::factory()->create();
 
     return Game::factory()
-        ->for($category)
+        ->for($category ?? Category::factory()->create())
         ->create();
 }
 

--- a/tests/Factories.php
+++ b/tests/Factories.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Models\Day;
+
+function createDay(): Day
+{
+    return Day::factory()->create();
+}
+
+function createPastDay(): Day
+{
+    return Day::factory()->create([
+        'date' => now()->sub('day', 1),
+    ]);
+}

--- a/tests/Factories.php
+++ b/tests/Factories.php
@@ -29,8 +29,6 @@ function createEvent(): Event
 
 function createGameWithCategory(Category $category = null): Game
 {
-    $category = Category::factory()->create();
-
     return Game::factory()
         ->for($category ?? Category::factory()->create())
         ->create();

--- a/tests/Factories.php
+++ b/tests/Factories.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Day;
+use App\Models\Event;
 
 function createDay(): Day
 {
@@ -12,4 +13,12 @@ function createPastDay(): Day
     return Day::factory()->create([
         'date' => now()->sub('day', 1),
     ]);
+}
+
+function createEvent(): Event
+{
+    return Event::factory()
+        ->create([
+            'day_id' => createDay()->id,
+        ]);
 }

--- a/tests/Factories.php
+++ b/tests/Factories.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Models\Category;
 use App\Models\Day;
 use App\Models\Event;
+use App\Models\Game;
 
 function createDay(): Day
 {
@@ -21,4 +23,13 @@ function createEvent(): Event
         ->create([
             'day_id' => createDay()->id,
         ]);
+}
+
+function createGameWithCategory()
+{
+    $category = Category::factory()->create();
+
+    return Game::factory()
+        ->for($category)
+        ->create();
 }

--- a/tests/Factories.php
+++ b/tests/Factories.php
@@ -4,6 +4,8 @@ use App\Models\Category;
 use App\Models\Day;
 use App\Models\Event;
 use App\Models\Game;
+use App\Models\Table;
+use Illuminate\Support\Facades\Auth;
 
 function createDay(): Day
 {
@@ -32,4 +34,20 @@ function createGameWithCategory()
     return Game::factory()
         ->for($category)
         ->create();
+}
+
+function createTable(
+    Day $day = null,
+    string $start_hour = '14:00',
+    int $playersNumber = 2,
+): Table {
+    return Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day ?? Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'start_hour' => $start_hour,
+            'players_number' => $playersNumber,
+        ]);
 }

--- a/tests/Feature/Actions/CountTableByTimeSlotActionTest.php
+++ b/tests/Feature/Actions/CountTableByTimeSlotActionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Actions\Table\CountTablesForTimeSlotAction;
+use App\Models\Table;
+
+const START_TIME_AFTERNOON = 13;
+const END_TIME_AFTERNOON = 19;
+const START_TIME_EVENING = 19;
+const END_TIME_EVENING = 23;
+
+beforeEach(function () {
+    login();
+});
+
+test('It counts the afternoon tables', function () {
+    // Create 2 afternoon tables
+    createTable(start_hour: '13:00');
+    createTable(start_hour: '17:00');
+
+    // Create tables out of afternoon time slot
+    createTable(start_hour: '19:00');
+
+    $afternoonTablesCount = app(CountTablesForTimeSlotAction::class)(Table::all(), START_TIME_AFTERNOON,
+        END_TIME_AFTERNOON);
+
+    expect($afternoonTablesCount)->toBe(2);
+});
+
+test('It counts the evening tables', function () {
+    // Create 3 evening tables
+    createTable(start_hour: '19:00');
+    createTable(start_hour: '20:00');
+    createTable(start_hour: '21:00');
+
+    // Create tables out of evening time slot
+    createTable(start_hour: '18:00');
+
+    $eveningTablesCount = app(CountTablesForTimeSlotAction::class)(Table::all(), START_TIME_EVENING, END_TIME_EVENING);
+
+    expect($eveningTablesCount)->toBe(3);
+});

--- a/tests/Feature/Actions/DefineChannelIdActionTest.php
+++ b/tests/Feature/Actions/DefineChannelIdActionTest.php
@@ -2,7 +2,7 @@
 
 use App\Actions\Discord\DefineChannelIdAction;
 
-test('The correct channel ID is returned according to the day of a date', function (string $date, int $discordChannel) {
+test('Define channel ID according to the day of a date', function (string $date, int $discordChannel) {
     $channelId = app(DefineChannelIdAction::class)($date);
 
     expect($channelId)->toBe($discordChannel);

--- a/tests/Feature/Actions/UserSubscriptionActionTest.php
+++ b/tests/Feature/Actions/UserSubscriptionActionTest.php
@@ -1,18 +1,24 @@
 <?php
 
 use App\Actions\UserSubscriptionAction;
+use App\Models\Category;
+use App\Models\Day;
+use App\Models\Game;
 use App\Models\Table;
-use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 test('The action class does its job correctly', function () {
-    $this->seed();
+    login();
 
-    $this->actingAs(User::first());
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
 
-    $table = Table::first();
-    $user = User::first();
+    app(UserSubscriptionAction::class)->execute($table);
 
-    app(UserSubscriptionAction::class)->execute($table, $user);
-
-    expect($table->users->count())->toBe(2);
+    expect($table->users->count())->toBeOne();
 });

--- a/tests/Feature/Actions/UserSubscriptionActionTest.php
+++ b/tests/Feature/Actions/UserSubscriptionActionTest.php
@@ -1,22 +1,11 @@
 <?php
 
 use App\Actions\UserSubscriptionAction;
-use App\Models\Category;
-use App\Models\Day;
-use App\Models\Game;
-use App\Models\Table;
-use Illuminate\Support\Facades\Auth;
 
 test('The action class does its job correctly', function () {
     login();
 
-    $table = Table::factory()
-        ->for(Category::factory())
-        ->for(Game::factory())
-        ->for(Day::factory())
-        ->create([
-            'organizer_id' => Auth::user()->id,
-        ]);
+    $table = createTable();
 
     app(UserSubscriptionAction::class)->execute($table);
 

--- a/tests/Feature/Http/Controllers/DashboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/DashboardControllerTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    login();
+});
+
+test('It renders the index page', function () {
+    $response = get(route('dashboard'));
+
+    expect($response)->toBeOk();
+});

--- a/tests/Feature/Http/Controllers/DayControllerTest.php
+++ b/tests/Feature/Http/Controllers/DayControllerTest.php
@@ -24,7 +24,7 @@ test('The create page is rendered correctly', function () {
 });
 
 test('The show page is rendered correctly', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     $response = get(route('days.show', $day));
 
@@ -32,7 +32,7 @@ test('The show page is rendered correctly', function () {
 });
 
 test('A day can not be created twice', function () {
-    Day::factory()->create();
+    createDay();
 
     $response = $this->post(route('days.store'), [
         'date' => now(),
@@ -60,9 +60,7 @@ test('A day is created successfully', function () {
 });
 
 test('The past days are hidden from index page', function () {
-    $pastDay = Day::factory()->create([
-        'date' => now()->sub('day', 1),
-    ]);
+    $pastDay = createPastDay();
 
     $response = get(route('days.index'));
 
@@ -72,7 +70,7 @@ test('The past days are hidden from index page', function () {
 });
 
 test('the edit warning page is rendered correctly', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     $response = get(route('days.warning', $day));
 
@@ -80,7 +78,7 @@ test('the edit warning page is rendered correctly', function () {
 });
 
 test('the warning could not be store without an explanation', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     $response = patch(route('days.confirm_warning', $day), [
         'explanation' => '',
@@ -90,7 +88,7 @@ test('the warning could not be store without an explanation', function () {
 });
 
 test('A warning message can be stored', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     $response = patch(route('days.confirm_warning', $day), [
         'explanation' => 'Example of explanation',
@@ -102,7 +100,7 @@ test('A warning message can be stored', function () {
 });
 
 test('The warning message is visible on the show page if exists', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     patch(route('days.confirm_warning', $day), [
         'explanation' => 'Example of explanation',
@@ -114,7 +112,7 @@ test('The warning message is visible on the show page if exists', function () {
 });
 
 test('The warning message is hidden when it doesnt exists', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
     $explanationTest = 'Example of explanation';
 
     $response = get(route('days.show', $day));
@@ -124,14 +122,14 @@ test('The warning message is hidden when it doesnt exists', function () {
 });
 
 test('the cancel page is rendered correctly', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
     $response = get(route('days.cancel', $day));
 
     expect($response)->toBeOk();
 });
 
 test('the day cancelation could not be executed without an explanation', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     $response = patch(route('days.confirm_cancel', $day), [
         'explanation' => '',
@@ -141,7 +139,7 @@ test('the day cancelation could not be executed without an explanation', functio
 });
 
 test('The cancelation message is stored', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',
@@ -153,7 +151,7 @@ test('The cancelation message is stored', function () {
 });
 
 test('The cancelation of a day must block the ability to create table', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',
@@ -165,7 +163,7 @@ test('The cancelation of a day must block the ability to create table', function
 });
 
 test('The cancellation of a day must delete every tables created', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',
@@ -175,7 +173,7 @@ test('The cancellation of a day must delete every tables created', function () {
 });
 
 test('The cancellation message is visible on the show page if exists', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',
@@ -202,7 +200,7 @@ test('The action buttons are hidden for non admin users on days index page', fun
 });
 
 test('The create buttons are hidden for a cancelled day', function () {
-    $day = Day::factory()->create();
+    $day = createDay();
 
     patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',

--- a/tests/Feature/Http/Controllers/DayControllerTest.php
+++ b/tests/Feature/Http/Controllers/DayControllerTest.php
@@ -1,35 +1,39 @@
 <?php
 
 use App\Models\Day;
-use App\Models\User;
 
-use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\get;
+use function Pest\Laravel\patch;
+use function Pest\Laravel\post;
 
 beforeEach(function () {
-    $this->seed();
-    actingAs(User::first());
+    login();
 });
 
 test('The index page is rendered correctly', function () {
-    $response = $this->get(route('days.index'));
+    $response = get(route('days.index'));
 
     expect($response)->toBeOk();
 });
 
 test('The create page is rendered correctly', function () {
-    $response = $this->get(route('days.create'));
+    $response = get(route('days.create'));
 
     expect($response)->toBeOk();
 });
 
 test('The show page is rendered correctly', function () {
-    $response = $this->get(route('days.show', Day::first()->id));
+    $day = Day::factory()->create();
+
+    $response = get(route('days.show', $day));
 
     expect($response)->toBeOk();
 });
 
 test('A day can not be created twice', function () {
+    Day::factory()->create();
+
     $response = $this->post(route('days.store'), [
         'date' => now(),
     ]);
@@ -46,17 +50,13 @@ test('A day can not be created without choosing a date', function () {
 });
 
 test('A day is created successfully', function () {
-    $date = now()->add('day', 1);
-
-    $response = $this->post(route('days.store'), [
-        'date' => $date,
+    post(route('days.store'), [
+        'date' => now(),
     ]);
 
-    expect($response)->toHaveValid(['date'])
-        ->and($response)->toBeRedirect(route('days.index'))
-        ->and([
-            'date' => $date,
-        ])->toBeInDatabase(table: 'days');
+    assertDatabaseHas('days', [
+        'date' => now(),
+    ]);
 });
 
 test('The past days are hidden from index page', function () {
@@ -64,15 +64,15 @@ test('The past days are hidden from index page', function () {
         'date' => now()->sub('day', 1),
     ]);
 
-    $response = $this->get(route('days.index'));
+    $response = get(route('days.index'));
 
     expect($response)
-        ->toBeOk()
-        ->not->toContainText($pastDay->date->format('d/m/Y'));
+        ->not
+        ->toContainText($pastDay->date->format('d/m/Y'));
 });
 
 test('the edit warning page is rendered correctly', function () {
-    $day = Day::first();
+    $day = Day::factory()->create();
 
     $response = get(route('days.warning', $day));
 
@@ -80,9 +80,9 @@ test('the edit warning page is rendered correctly', function () {
 });
 
 test('the warning could not be store without an explanation', function () {
-    $day = Day::first();
+    $day = Day::factory()->create();
 
-    $response = $this->patch(route('days.confirm_warning', $day), [
+    $response = patch(route('days.confirm_warning', $day), [
         'explanation' => '',
     ]);
 
@@ -90,51 +90,50 @@ test('the warning could not be store without an explanation', function () {
 });
 
 test('A warning message can be stored', function () {
-    $day = Day::first();
-    $explanationTest = 'Example of explanation';
+    $day = Day::factory()->create();
 
-    $response = $this->patch(route('days.confirm_warning', $day), [
-        'explanation' => $explanationTest,
+    $response = patch(route('days.confirm_warning', $day), [
+        'explanation' => 'Example of explanation',
     ]);
 
-    expect($day->refresh()->explanation)->toBe($explanationTest)
+    expect($day->refresh()->explanation)
+        ->toBe('Example of explanation')
         ->and($response)->toBeRedirect(route('days.index'));
 });
 
 test('The warning message is visible on the show page if exists', function () {
-    $day = Day::first();
-    $explanationTest = 'Example of explanation';
+    $day = Day::factory()->create();
 
-    $this->patch(route('days.confirm_warning', $day), [
-        'explanation' => $explanationTest,
+    patch(route('days.confirm_warning', $day), [
+        'explanation' => 'Example of explanation',
     ]);
 
-    $showDayView = get(route('days.show', $day));
+    $response = get(route('days.show', $day));
 
-    expect($showDayView)->toContainText($explanationTest);
+    expect($response)->toContainText('Example of explanation');
 });
 
 test('The warning message is hidden when it doesnt exists', function () {
-    $day = Day::first();
+    $day = Day::factory()->create();
     $explanationTest = 'Example of explanation';
 
-    $showDayView = get(route('days.show', $day));
+    $response = get(route('days.show', $day));
 
-    expect($showDayView)->not()->toContainText($explanationTest)
-        ->and($showDayView)->not()->toContainText("<h3 class='my-4 text-white text-center w-full bg-red-500 rounded-lg'>");
+    expect($response)->not()->toContainText($explanationTest)
+        ->and($response)->not()->toContainText("<h3 class='my-4 text-white text-center w-full bg-red-500 rounded-lg'>");
 });
 
 test('the cancel page is rendered correctly', function () {
-    $day = Day::first();
-    $showCancelDayView = get(route('days.cancel', $day));
+    $day = Day::factory()->create();
+    $response = get(route('days.cancel', $day));
 
-    expect($showCancelDayView)->toBeOk();
+    expect($response)->toBeOk();
 });
 
-test('the table cancelation could not be executed without an explanation', function () {
-    $day = Day::first();
+test('the day cancelation could not be executed without an explanation', function () {
+    $day = Day::factory()->create();
 
-    $response = $this->patch(route('days.confirm_cancel', $day), [
+    $response = patch(route('days.confirm_cancel', $day), [
         'explanation' => '',
     ]);
 
@@ -142,24 +141,22 @@ test('the table cancelation could not be executed without an explanation', funct
 });
 
 test('The cancelation message is stored', function () {
-    $day = Day::first();
-    $cancellationMessage = 'Example of explanation';
+    $day = Day::factory()->create();
 
-    $this->patch(route('days.confirm_cancel', $day), [
-        'explanation' => $cancellationMessage,
+    patch(route('days.confirm_cancel', $day), [
+        'explanation' => 'Example of explanation',
     ]);
 
     expect($day->refresh())
         ->explanation
-        ->toBe($cancellationMessage);
+        ->toBe('Example of explanation');
 });
 
 test('The cancelation of a day must block the ability to create table', function () {
-    $day = Day::first();
-    $cancellationMessage = 'Example of explanation';
+    $day = Day::factory()->create();
 
-    $this->patch(route('days.confirm_cancel', $day), [
-        'explanation' => $cancellationMessage,
+    patch(route('days.confirm_cancel', $day), [
+        'explanation' => 'Example of explanation',
     ]);
 
     expect($day->refresh())
@@ -168,9 +165,9 @@ test('The cancelation of a day must block the ability to create table', function
 });
 
 test('The cancellation of a day must delete every tables created', function () {
-    $day = Day::first();
+    $day = Day::factory()->create();
 
-    $this->patch(route('days.confirm_cancel', $day), [
+    patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',
     ]);
 
@@ -178,48 +175,40 @@ test('The cancellation of a day must delete every tables created', function () {
 });
 
 test('The cancellation message is visible on the show page if exists', function () {
-    $day = Day::first();
-    $explanationTest = 'Example of explanation';
+    $day = Day::factory()->create();
 
-    $this->patch(route('days.confirm_cancel', $day), [
-        'explanation' => $explanationTest,
+    patch(route('days.confirm_cancel', $day), [
+        'explanation' => 'Example of explanation',
     ]);
 
-    $showDayView = get(route('days.show', $day));
+    $response = get(route('days.show', $day));
 
-    expect($showDayView)->toContainText($explanationTest);
+    expect($response)->toContainText('Example of explanation');
 });
 
 test('The action buttons are visible for admin users on days index page', function () {
     loginAdmin();
+    Day::factory()->create();
 
-    $indexPageResponse = get(route('days.index'));
-
-    $indexPageResponse->assertSee('img/cancel.png');
-    $indexPageResponse->assertSee('img/warning.png');
+    get(route('days.index'))
+        ->assertSee('img/cancel.png')
+        ->assertSee('img/warning.png');
 });
 
 test('The action buttons are hidden for non admin users on days index page', function () {
-    $user = User::firstWhere('admin', false);
-
-    actingAs($user)
-        ->get(route('days.index'))
+    get(route('days.index'))
         ->assertDontSee('img/cancel.png')
         ->assertDontSee('img/warning.png');
 });
 
 test('The create buttons are hidden for a cancelled day', function () {
-    $day = Day::first();
-    $user = User::first();
+    $day = Day::factory()->create();
 
-    $explanationTest = 'Example of explanation';
-
-    $this->patch(route('days.confirm_cancel', $day), [
-        'explanation' => $explanationTest,
+    patch(route('days.confirm_cancel', $day), [
+        'explanation' => 'Example of explanation',
     ]);
 
-    actingAs($user)
-        ->get(route('days.show', $day))
+    get(route('days.show', $day))
         ->assertDontSee('img/game-table.png')
         ->assertDontSee('img/calendar.png');
 });

--- a/tests/Feature/Http/Controllers/GameControllerTest.php
+++ b/tests/Feature/Http/Controllers/GameControllerTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use function Pest\Laravel\get;
+
+test('The create game page is rendered', function () {
+    login();
+
+    $response = get('games/create');
+
+    expect($response)->toBeRedirect('/admin/games/create');
+});

--- a/tests/Feature/Http/Controllers/TableControllerTest.php
+++ b/tests/Feature/Http/Controllers/TableControllerTest.php
@@ -7,166 +7,208 @@ use App\Models\Game;
 use App\Models\Table;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Event;
+use Tests\RequestFactories\TableRequestFactory;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\delete;
 use function Pest\Laravel\get;
+use function Pest\Laravel\patch;
+use function Pest\Laravel\post;
+
+beforeEach(function () {
+    login();
+});
 
 it('Display all game categories in the create view form', function () {
-    $this->seed();
-    $this->actingAs(User::first());
+    $day = createDay();
+    $category = Category::factory()->create();
 
-    $day = Day::first();
-    $response = $this->get(route('table.create', $day));
+    $response = get(route('table.create', $day));
 
     $response->assertOk();
 
-    foreach (Category::all() as $category) {
-        $response->assertSee($category->name);
-    }
+    $response->assertSee($category->name);
 });
 
 it('Creates a new table', function () {
-    $this->seed();
-
-    $this->actingAs(User::first());
-
+    $day = createDay();
+    $game = createGameWithCategory();
     mockHttpClient();
 
-    $response = $this->post(route('table.store', Day::first()->id), [
-        'organizer_id' => User::first()->id,
-        'day_id' => Day::first()->id,
-        'game_id' => Game::first()->id,
-        'category_id' => Category::first()->id,
-        'players_number' => 5,
-        'start_hour' => '21:00',
-    ]);
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('21:00')
+        ->create();
+
+    $response = post(route('table.store', $day), $tableAttributes);
 
     expect($response)
-        ->toBeRedirect(route('days.show', Day::first()->id))
-        ->and(Table::count())->toBe(2);
-});
+        ->toBeRedirect(route('days.show', $day))
+        ->and(Table::count())->toBeOne();
 
-it('Can not create the same table twice', function () {
-    $this->seed();
-    $this->actingAs(User::first());
-
-    mockHttpClient();
-
-    $day = Day::first();
-
-    // Try to create a new table once
-    $response = $this->post(route('table.store', $day), [
-        'organizer_id' => User::first()->id,
-        'day_id' => Day::first()->id,
-        'game_id' => Game::first()->id,
-        'category_id' => Category::first()->id,
-        'players_number' => 5,
-        'start_hour' => '21:00',
-    ]);
-
-    expect(Table::count())->toBe(2)
-        ->and($response)
-        ->toBeRedirect(route('days.show', Day::first()->id))
-        ->toHaveSession('error');
-})->skip();
-
-it('Updates a table', function () {
-    $this->seed();
-    $this->actingAs(User::first());
-
-    mockHttpClient();
-
-    $response = $this->patch(route('table.update', Table::first()->id), [
-        'day_id' => Day::first()->id,
-        'game_id' => Game::first()->id,
-        'category_id' => Category::first()->id,
-        'players_number' => 5,
-        'start_hour' => '21:00',
-    ]);
-
-    $tableUpdated = Table::first();
-
-    expect($tableUpdated->game_id)->toBe('1')
-        ->and($tableUpdated->players_number)->toBe(5)
-        ->and($tableUpdated->start_hour)->toBe('21:00')
-        ->and($response)->toBeRedirect(route('days.show', Day::first()->id));
-
-});
-
-it('Can not create a table without the number of players', function () {
-    $this->seed();
-    $this->actingAs(User::first());
-
-    $response = $this->post(route('table.store', Day::first()->id), [
-        'organizer_id' => User::first()->id,
-        'day_id' => Day::first()->id,
-        'game_id' => Game::first()->id,
-        'category_id' => Category::first()->id,
-        'start_hour' => '21:00',
-    ]);
-
-    expect($response)->toHaveInvalid('players_number');
+    assertDatabaseHas('tables', $tableAttributes);
 });
 
 it('Can not create a table without a start hour', function () {
-    $this->seed();
-    $this->actingAs(User::first());
+    $day = createDay();
+    $game = createGameWithCategory();
 
-    $response = $this->post(route('table.store', Day::first()->id), [
-        'organizer_id' => User::first()->id,
-        'day_id' => Day::first()->id,
-        'game_id' => Game::first()->id,
-        'category_id' => Category::first()->id,
-        'players_number' => 5,
-    ]);
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('')
+        ->create();
+
+    $response = post(route('table.store', Day::first()->id), $tableAttributes);
 
     expect($response)->toHaveInvalid('start_hour');
 });
 
 it('Can not create a table without a game', function () {
-    $this->seed();
-    $this->actingAs(User::first());
+    $day = createDay();
+    $game = createGameWithCategory();
 
-    $response = $this->post(route('table.store', Day::first()->id), [
-        'organizer_id' => User::first()->id,
-        'day_id' => Day::first()->id,
-        'players_number' => 5,
-        'start_hour' => '21:00',
-    ]);
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame(null)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('')
+        ->create();
+
+    $response = $this->post(route('table.store', $day->id), $tableAttributes);
 
     expect($response)->toHaveInvalid('game_id');
 });
 
-it('Subscribes a user to a table', function () {
-    $this->seed();
+it('Can not create a table without the number of players', function () {
+    $day = createDay();
+    $game = createGameWithCategory();
+
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(null)
+        ->withStartHour('14:00')
+        ->create();
+
+    $response = $this->post(route('table.store', $day->id), $tableAttributes);
+
+    expect($response)->toHaveInvalid('players_number');
+});
+
+it('Can not create the same table twice', function () {
     login();
+    $day = createDay();
+    $game = createGameWithCategory();
+    mockHttpClient();
 
-    expect(Table::first()->users->count())->toBe(1);
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('21:00')
+        ->create();
 
-    $this->get(route('table.subscribe', Table::first()));
+    // Create a new table
+    post(route('table.store', $day), $tableAttributes);
 
-    expect(Table::first()->users->count())->toBe(2);
+    // Try to create the same table twice
+    $response = post(route('table.store', $day), $tableAttributes);
+
+    expect(Table::count())->toBeOne()
+        ->and($response)
+        ->toBeRedirect(route('days.show', $day->id))
+        ->toHaveSession('error');
+});
+
+it('Updates a table', function () {
+    login();
+    mockHttpClient();
+
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->has(User::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'start_hour' => '21:00',
+        ]);
+
+    $response = patch(route('table.update', $table), [
+        'day_id' => Day::first()->id,
+        'game_id' => Game::first()->id,
+        'category_id' => Category::first()->id,
+        'players_number' => 3,
+        'start_hour' => '15:00',
+    ]);
+
+    $tableUpdated = Table::first();
+
+    expect($tableUpdated->game_id)->toBe('1')
+        ->and($tableUpdated->players_number)->toBe(3)
+        ->and($tableUpdated->start_hour)->toBe('15:00')
+        ->and($response)->toBeRedirect(route('days.show', Day::first()->id));
+
+});
+
+it('Subscribes a user to a table', function () {
+    mockHttpClient();
+
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
+
+    get(route('table.subscribe', $table));
+
+    expect($table->users->count())->toBeOne();
 });
 
 it('Unsubscribes a user of a table', function () {
-    $this->seed();
-    login();
+    mockHttpClient();
 
-    $table = Table::first();
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
 
-    expect(Table::first()->users()->count())->toBe(1);
+    get(route('table.unsubscribe', $table));
 
-    $this->get(route('table.unsubscribe', Table::first()));
-
-    expect(Table::first()->users()->count())->toBe(1);
+    expect($table->users()->count())->toBe(0);
 });
 
 it('Can not subscribe a user already subscribed to another table with the same start hour for the same day', function () {
-    $this->seed();
-    login();
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'start_hour' => '21:00',
+        ]);
 
-    app(UserSubscriptionAction::class)->execute(Table::first(), Auth::user());
+    app(UserSubscriptionAction::class)->execute($table, Auth::user());
 
     $anotherTableAtSameHour = Table::factory()
         ->for(Game::factory())
@@ -179,133 +221,153 @@ it('Can not subscribe a user already subscribed to another table with the same s
 
     $response = get(route('table.subscribe', $anotherTableAtSameHour));
 
-    $response->assertRedirect(route('days.show', Table::first()->day));
+    $response->assertRedirect(route('days.show', $table->day));
 
     expect($anotherTableAtSameHour->users->count())->toBe(0);
 });
 
 test('A user can not see the edit action button for a table he didnt created', function () {
-    $this->seed();
+    $day = createDay();
 
-    $user = User::factory()->create();
+    $anotherUser = User::factory()->create();
 
-    $this->actingAs($user)
-        ->get(route('days.show', Day::first()->id))
+    actingAs($anotherUser)
+        ->get(route('days.show', $day))
         ->assertOk()
         ->assertDontSee('img/edit.png');
 });
 
 test('An admin user can see the edit action button for a table he didnt created', function () {
-    $this->seed();
+    loginAdmin();
+    $day = createDay();
 
-    $adminUser = User::factory()->create([
-        'admin' => true,
-    ]);
+    Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day)
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'start_hour' => '21:00',
+        ]);
 
-    $this->actingAs($adminUser);
-
-    $response = $this->get(route('days.show', Day::first()->id));
-
-    $response
+    get(route('days.show', $day))
         ->assertOk()
         ->assertSee('img/edit.png');
 });
 
 test('A user can not render the edit page for a table he didnt create', function () {
-    $this->seed();
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
 
     $anotherUser = User::factory()->create();
 
-    $table = Table::first();
-
-    $this
-        ->actingAs($anotherUser)
+    actingAs($anotherUser)
         ->get(route('table.edit', $table))
         ->assertForbidden();
 });
 
 test('An admin user can render the edit page for a table he didnt create', function () {
-    $this->seed();
+    loginAdmin();
 
-    $adminUser = User::factory()->create([
-        'admin' => true,
-    ]);
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
 
-    $table = Table::first();
-
-    $this
-        ->actingAs($adminUser)
-        ->get(route('table.edit', $table))
-        ->assertOk();
+    get(route('table.edit', $table))->assertOk();
 });
 
 test('A user can not see the delete action button for a table he didnt created', function () {
-    $this->seed();
+    $day = createDay();
 
-    $user = User::factory()->create();
+    $anotherUser = User::factory()->create();
 
-    $this
-        ->actingAs($user)
-        ->get(route('days.show', Day::first()->id))
+    Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for(Day::factory())
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
+
+    actingAs($anotherUser)
+        ->get(route('days.show', $day))
         ->assertOk()
         ->assertDontSee('img/delete.png');
 });
 
 test('An admin user can see the delete action button for a table he didnt created', function () {
-    $this->seed();
+    loginAdmin();
+    $day = createDay();
 
-    $this
-        ->actingAs(User::first())
-        ->get(route('days.show', Day::first()->id))
+    Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day)
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
+
+    get(route('days.show', $day))
         ->assertOk()
         ->assertSee('img/delete.png');
 });
 
 test('Deletes a table', function () {
-    $this->seed();
-    $this->actingAs(User::first());
-
+    $day = createDay();
     mockHttpClient();
 
-    expect(Table::all()->count())->toBe(1);
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day)
+        ->create([
+            'organizer_id' => Auth::user()->id,
+        ]);
 
-    $this->delete(route('table.delete', Table::first()));
+    delete(route('table.delete', $table));
 
     expect(Table::all()->count())->toBe(0);
 });
 
 test('A user could not subscribe to a table if the max number of players is reached', function () {
-    Event::fake();
+    $day = createDay();
+    mockHttpClient();
 
-    $this->seed();
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day)
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'players_number' => 1,
+        ]);
 
-    $user = User::first();
     $anotherUser = User::factory()->create();
 
-    $table = Table::first();
-    $day = Day::first();
-
-    $this
-        ->actingAs($user)
-        ->get(route('table.subscribe', [$table, $user]));
-
-    expect($table->users()->count())->toBe(2);
+    get(route('table.subscribe', $table));
 
     // The user can not subscribe to a table and is redirected to the correct day table with an error message
-    $response = $this
-        ->actingAs($anotherUser)
-        ->get(route('table.subscribe', [$table, $anotherUser]));
+    $response = actingAs($anotherUser)
+        ->get(route('table.subscribe', $table));
 
-    expect($response)->toBeRedirect(route('days.show', [$day]));
+    expect($response)
+        ->toBeRedirect(route('days.show', $day))
+        ->and($table->users()->count())->toBeOne();
 });
 
 test('Table creation is not allowed if a day has been cancelled', function () {
-    $this->seed();
-    actingAs(User::first());
+    $day = createDay();
 
-    $day = Day::first();
-
-    $this->patch(route('days.confirm_cancel', $day), [
+    patch(route('days.confirm_cancel', $day), [
         'explanation' => 'Example of explanation',
     ]);
 

--- a/tests/Feature/Logic/UserLogicTest.php
+++ b/tests/Feature/Logic/UserLogicTest.php
@@ -3,21 +3,29 @@
 use App\Actions\UserSubscriptionAction;
 use App\Logic\UserLogic;
 use App\Models\Category;
-use App\Models\Day;
 use App\Models\Game;
 use App\Models\Table;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
 test('it should return true if an user is subscribed to a table with the same start hour for the current day', function () {
-    $this->seed();
     login();
+    $day = createDay();
 
-    app(UserSubscriptionAction::class)->execute(Table::first(), Auth::user());
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day)
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'start_hour' => '21:00',
+        ]);
+
+    app(UserSubscriptionAction::class)->execute($table);
 
     $anotherTableAtSameHour = Table::factory()
         ->for(Game::factory())
-        ->for(Day::first())
+        ->for($day)
         ->for(Category::first())
         ->has(User::factory())
         ->create([
@@ -26,19 +34,29 @@ test('it should return true if an user is subscribed to a table with the same st
         ]);
 
     $hasAlreadySubscribed = app(UserLogic::class)
-        ->hasSubscribedToAnotherTableWithTheSameStartHour(Day::first(), $anotherTableAtSameHour);
+        ->hasSubscribedToAnotherTableWithTheSameStartHour($day, $anotherTableAtSameHour);
 
-    expect(Table::first()->users->count())
-        ->toBe(2)
-        ->and($hasAlreadySubscribed)->toBe(true);
+    expect($table->users->count())
+        ->toBeOne()
+        ->and($hasAlreadySubscribed)
+        ->toBeTrue();
 });
 
 test('it should return false if an user is not already subscribed to another table with the same start hour for the current day', function () {
-    $this->seed();
     login();
+    $day = createDay();
+
+    $table = Table::factory()
+        ->for(Category::factory())
+        ->for(Game::factory())
+        ->for($day)
+        ->create([
+            'organizer_id' => Auth::user()->id,
+            'start_hour' => '21:00',
+        ]);
 
     $hasAlreadySubscribed = app(UserLogic::class)
-        ->hasSubscribedToAnotherTableWithTheSameStartHour(Day::first(), Table::first());
+        ->hasSubscribedToAnotherTableWithTheSameStartHour($day, $table);
 
-    expect($hasAlreadySubscribed)->toBe(false);
+    expect($hasAlreadySubscribed)->toBeFalse();
 });

--- a/tests/Feature/Logic/UserLogicTest.php
+++ b/tests/Feature/Logic/UserLogicTest.php
@@ -2,36 +2,16 @@
 
 use App\Actions\UserSubscriptionAction;
 use App\Logic\UserLogic;
-use App\Models\Category;
-use App\Models\Game;
-use App\Models\Table;
-use App\Models\User;
-use Illuminate\Support\Facades\Auth;
 
 test('it should return true if an user is subscribed to a table with the same start hour for the current day', function () {
     login();
     $day = createDay();
 
-    $table = Table::factory()
-        ->for(Category::factory())
-        ->for(Game::factory())
-        ->for($day)
-        ->create([
-            'organizer_id' => Auth::user()->id,
-            'start_hour' => '21:00',
-        ]);
+    $table = createTable(day: $day, start_hour: '21:00');
 
     app(UserSubscriptionAction::class)->execute($table);
 
-    $anotherTableAtSameHour = Table::factory()
-        ->for(Game::factory())
-        ->for($day)
-        ->for(Category::first())
-        ->has(User::factory())
-        ->create([
-            'organizer_id' => User::first()->id,
-            'start_hour' => '21:00',
-        ]);
+    $anotherTableAtSameHour = createTable(day: $day, start_hour: '21:00');
 
     $hasAlreadySubscribed = app(UserLogic::class)
         ->hasSubscribedToAnotherTableWithTheSameStartHour($day, $anotherTableAtSameHour);
@@ -46,14 +26,7 @@ test('it should return false if an user is not already subscribed to another tab
     login();
     $day = createDay();
 
-    $table = Table::factory()
-        ->for(Category::factory())
-        ->for(Game::factory())
-        ->for($day)
-        ->create([
-            'organizer_id' => Auth::user()->id,
-            'start_hour' => '21:00',
-        ]);
+    $table = createTable(day: $day, start_hour: '21:00');
 
     $hasAlreadySubscribed = app(UserLogic::class)
         ->hasSubscribedToAnotherTableWithTheSameStartHour($day, $table);

--- a/tests/Feature/Repositories/GameRepositoriesTest.php
+++ b/tests/Feature/Repositories/GameRepositoriesTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\Category;
+use App\Repositories\GameRepository;
+
+test('Retrieve games for a choosen category', function () {
+    login();
+
+    $category = Category::factory()->create();
+
+    createGameWithCategory($category);
+    createGameWithCategory($category);
+
+    $games = app(GameRepository::class)->findByCategory($category->id);
+    expect($games->count())->toBe(2);
+});

--- a/tests/RequestFactories/EventRequestFactory.php
+++ b/tests/RequestFactories/EventRequestFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\RequestFactories;
+
+class EventRequestFactory
+{
+    private string $name = 'example';
+
+    private string $description = 'description';
+
+    private string $start_hour = '14:00';
+
+    public static function new(): self
+    {
+        return new self;
+    }
+
+    public function create(array $extra = []): array
+    {
+        return $extra + [
+            'name' => $this->name,
+            'description' => $this->description,
+            'start_hour' => $this->start_hour,
+        ];
+    }
+
+    public function withName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function withDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function withStartHour(string $startHour): self
+    {
+        $this->start_hour = $startHour;
+
+        return $this;
+    }
+}

--- a/tests/RequestFactories/TableRequestFactory.php
+++ b/tests/RequestFactories/TableRequestFactory.php
@@ -17,7 +17,7 @@ class TableRequestFactory
 
     private Category $category;
 
-    private int $players_number;
+    private ?int $players_number;
 
     private string $start_hour;
 
@@ -33,7 +33,7 @@ class TableRequestFactory
             'day_id' => $this->day->id,
             'game_id' => $this->game->id ?? null,
             'category_id' => $this->category->id,
-            'players_number' => $this->players_number,
+            'players_number' => $this->players_number ?? null,
             'start_hour' => $this->start_hour,
         ];
     }
@@ -66,7 +66,7 @@ class TableRequestFactory
         return $this;
     }
 
-    public function withPlayersNumber(int $playersNumber): self
+    public function withPlayersNumber(?int $playersNumber): self
     {
         $this->players_number = $playersNumber;
 

--- a/tests/RequestFactories/TableRequestFactory.php
+++ b/tests/RequestFactories/TableRequestFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\RequestFactories;
+
+use App\Models\Category;
+use App\Models\Day;
+use App\Models\Game;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class TableRequestFactory
+{
+    private Authenticatable $organizer;
+
+    private Day $day;
+
+    private ?Game $game;
+
+    private Category $category;
+
+    private int $players_number;
+
+    private string $start_hour;
+
+    public static function new(): self
+    {
+        return new self;
+    }
+
+    public function create(array $extra = []): array
+    {
+        return $extra + [
+            'organizer_id' => $this->organizer->id,
+            'day_id' => $this->day->id,
+            'game_id' => $this->game->id ?? null,
+            'category_id' => $this->category->id,
+            'players_number' => $this->players_number,
+            'start_hour' => $this->start_hour,
+        ];
+    }
+
+    public function withOrganizer(Authenticatable $organizer): self
+    {
+        $this->organizer = $organizer;
+
+        return $this;
+    }
+
+    public function withDay(Day $day): self
+    {
+        $this->day = $day;
+
+        return $this;
+    }
+
+    public function withGame(?Game $game): self
+    {
+        $this->game = $game;
+
+        return $this;
+    }
+
+    public function withCategory(Category $category): self
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    public function withPlayersNumber(int $playersNumber): self
+    {
+        $this->players_number = $playersNumber;
+
+        return $this;
+    }
+
+    public function withStartHour(string $startHour): self
+    {
+        $this->start_hour = $startHour;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
# Description

The actual test suite was quite long to execute and needed to be improved.

Before that refactorization, the tests runs in 16 seconds.
After this refactorization, the tests runs in 13 seconds

Add some missing tests for GameController

## Type of change

- Refactorization (Code improvement without changing code behavior)

## Motivation of these modifications

- Almost every feature and unit tests call the global `$this->seed() `method that seed every fake model datas.
- However for some tests, it loads some unrelevant datas not needed for some tests.
- The second purpose of this PR is to improve the creation of test fixtures by creating Factories helper functions.
- Add new action class to compute number of table for afternoon and evening.

# Unit or Feature tests ?

Describe the tests that are added or modified within this pull request.

- [x] Rectorizing the TableControllerTest
- [x] Rectorizing the DayControllerTest
- [x] Rectorizing the EventControllerTest
- [x] Rectorizing the unit tests
- [x] Add tests for GameController
- [x] Add tests for DashboardController
- [x] Add test for new action class that computes count of afternoon and evening tables

Total tests coverage before this PR
![image](https://github.com/user-attachments/assets/d83ac587-beb3-4117-9f99-b14644f2a46b)

After this PR
![image](https://github.com/user-attachments/assets/517f1527-06c6-4a04-baef-4c9c67d86109)

# Actions checklist before merge (remove non relevant options):

- [x] Execute the code styles LINT command
- [x] Execute the static analysis tool (PHPStan for example)
- [x] I have commented my code, particularly in hard-to-understand areas

# Actions checklist after merge and CD (remove non relevant options):

- N/A