### PR TITLE
Fix User count on admin dashboard page

### DIFF
--- a/app/Filament/Widgets/DashboardStats.php
+++ b/app/Filament/Widgets/DashboardStats.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Models\Day;
 use App\Models\Game;
 use App\Models\Table;
+use App\Models\User;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
@@ -13,7 +14,7 @@ class DashboardStats extends BaseWidget
     protected function getStats(): array
     {
         return [
-            Stat::make('Total Utilisateurs', Table::count())
+            Stat::make('Total Utilisateurs', User::count())
                 ->icon('heroicon-o-user'),
             Stat::make('Total jeux', Game::count())
                 ->icon('heroicon-o-puzzle-piece'),


### PR DESCRIPTION
# Description

The number of users was incorrect on the admin dashboard main page

## Screenshots
![image](https://github.com/user-attachments/assets/6d23951c-c797-4f6d-a0e3-5992d53278d7)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [ ] This change requires a documentation update

Describe the tests that are added or modified within this pull request.

- N/A