### PR TITLE
Improve the discord notifications content

### DIFF
--- a/app/Enums/EmbedMessageContent.php
+++ b/app/Enums/EmbedMessageContent.php
@@ -4,7 +4,7 @@ namespace App\Enums;
 
 enum EmbedMessageContent: string
 {
-    case CREATED = 'Nouvelle table disponible sur ASGARD-TABLE-MANAGER';
+    case CREATED = 'Nouvelle table proposée';
     case UPDATED = 'Mise à jour de table';
     case DELETED = 'Annulation de table';
     case SUBSCRIBED = 'Inscription de joueur';

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -73,9 +73,4 @@ class CreateTableNotification extends DiscordNotification
     {
         return config('app.url').'/days/'.$discordNotificationData->day->id;
     }
-
-    private function setObjectMessage(string $gameCategory): string
-    {
-        return "Nouvelle table de $gameCategory";
-    }
 }

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -5,7 +5,6 @@ namespace App\Notifications\Discord\Table;
 use App\Actions\Discord\SendDiscordNotificationAction;
 use App\DataObjects\DiscordNotificationData;
 use App\Enums\EmbedColor;
-use App\Enums\EmbedMessageContent;
 use App\Notifications\Discord\DiscordNotification;
 use App\Notifications\Discord\Strategies\CreateMessageAndThread;
 use Illuminate\Support\Facades\Auth;
@@ -15,13 +14,13 @@ class CreateTableNotification extends DiscordNotification
     public function buildMessage(): self
     {
         $this->message = [
-            'content' => EmbedMessageContent::CREATED->value,
+            'content' => $this->setObjectMessage($this->discordNotificationData->game->category->name),
             'embeds' => [
                 [
-                    'title' => 'Table de : '.$this->discordNotificationData->game->name,
-                    'description' => self::setEmbedDescription($this->discordNotificationData),
+                    'title' => 'Jeu proposé : '.$this->discordNotificationData->game->name,
+                    'description' => $this->setEmbedDescription($this->discordNotificationData),
                     'author' => [
-                        'name' => 'Créateur : '.Auth::user()->name,
+                        'name' => 'Organisateur : '.Auth::user()->name,
                     ],
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
@@ -35,9 +34,11 @@ class CreateTableNotification extends DiscordNotification
                             'value' => $this->discordNotificationData->table->start_hour,
                             'inline' => true,
                         ],
-                    ],
-                    'footer' => [
-                        'text' => $this->discordNotificationData->table->description,
+                        [
+                            'name' => 'Description',
+                            'value' => $this->discordNotificationData->table->description,
+                            'inline' => false,
+                        ],
                     ],
                 ],
             ],
@@ -61,5 +62,10 @@ class CreateTableNotification extends DiscordNotification
     private static function setEmbedDescription(DiscordNotificationData $discordNotificationData): string
     {
         return 'Plus d\'informations sur '.config('app.url').'/days/'.$discordNotificationData->day->id;
+    }
+
+    private function setObjectMessage(string $gameCategory): string
+    {
+        return "Nouvelle table de $gameCategory";
     }
 }

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -18,11 +18,10 @@ class CreateTableNotification extends DiscordNotification
             'content' => EmbedMessageContent::CREATED->value,
             'embeds' => [
                 [
-                    'title' => 'Jeu proposé : '.$this->discordNotificationData->game->name,
-                    'description' => $this->setEmbedDescription($this->discordNotificationData),
                     'author' => [
                         'name' => 'Organisateur : '.Auth::user()->name,
                     ],
+                    'title' => 'Jeu proposé : '.$this->discordNotificationData->game->name,
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
                         [
@@ -43,6 +42,11 @@ class CreateTableNotification extends DiscordNotification
                         [
                             'name' => 'Description',
                             'value' => $this->discordNotificationData->table->description,
+                            'inline' => false,
+                        ],
+                        [
+                            'name' => 'Lien Inscription',
+                            'value' => '[Cliquez ici]('.$this->setEmbedDescription($this->discordNotificationData).')',
                             'inline' => false,
                         ],
                     ],
@@ -67,7 +71,7 @@ class CreateTableNotification extends DiscordNotification
 
     private static function setEmbedDescription(DiscordNotificationData $discordNotificationData): string
     {
-        return 'Pour s\'inscrire, cliquez ici : '.config('app.url').'/days/'.$discordNotificationData->day->id;
+        return config('app.url').'/days/'.$discordNotificationData->day->id;
     }
 
     private function setObjectMessage(string $gameCategory): string

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -61,7 +61,7 @@ class CreateTableNotification extends DiscordNotification
 
     private static function setEmbedDescription(DiscordNotificationData $discordNotificationData): string
     {
-        return 'Plus d\'informations sur '.config('app.url').'/days/'.$discordNotificationData->day->id;
+        return 'Pour s\'inscrire, cliquez ici : '.config('app.url').'/days/'.$discordNotificationData->day->id;
     }
 
     private function setObjectMessage(string $gameCategory): string

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications\Discord\Table;
 use App\Actions\Discord\SendDiscordNotificationAction;
 use App\DataObjects\DiscordNotificationData;
 use App\Enums\EmbedColor;
+use App\Enums\EmbedMessageContent;
 use App\Notifications\Discord\DiscordNotification;
 use App\Notifications\Discord\Strategies\CreateMessageAndThread;
 use Illuminate\Support\Facades\Auth;
@@ -14,7 +15,7 @@ class CreateTableNotification extends DiscordNotification
     public function buildMessage(): self
     {
         $this->message = [
-            'content' => $this->setObjectMessage($this->discordNotificationData->game->category->name),
+            'content' => EmbedMessageContent::CREATED->value,
             'embeds' => [
                 [
                     'title' => 'Jeu proposé : '.$this->discordNotificationData->game->name,
@@ -24,6 +25,11 @@ class CreateTableNotification extends DiscordNotification
                     ],
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
+                        [
+                            'name' => 'Catégorie',
+                            'value' => $this->discordNotificationData->game->category->name,
+                            'inline' => false,
+                        ],
                         [
                             'name' => 'Date',
                             'value' => $this->discordNotificationData->day->date->format('d/m/Y'),

--- a/app/Notifications/Discord/Table/UpdateTableNotification.php
+++ b/app/Notifications/Discord/Table/UpdateTableNotification.php
@@ -3,11 +3,11 @@
 namespace App\Notifications\Discord\Table;
 
 use App\Actions\Discord\SendDiscordNotificationAction;
+use App\DataObjects\DiscordNotificationData;
 use App\Enums\EmbedColor;
 use App\Enums\EmbedMessageContent;
 use App\Notifications\Discord\DiscordNotification;
 use App\Notifications\Discord\Strategies\CreateMessageIntoThread;
-use Illuminate\Support\Facades\Auth;
 
 class UpdateTableNotification extends DiscordNotification
 {
@@ -17,26 +17,23 @@ class UpdateTableNotification extends DiscordNotification
             'content' => EmbedMessageContent::UPDATED->value,
             'embeds' => [
                 [
-                    'title' => 'Table de : '.$this->discordNotificationData->game->name,
-                    'description' => self::setEmbedDescription($this->discordNotificationData->day->id),
-                    'author' => [
-                        'name' => 'Créateur : '.Auth::user()->name,
-                    ],
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
-                        [
-                            'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
-                            'inline' => true,
-                        ],
                         [
                             'name' => 'Heure',
                             'value' => $this->discordNotificationData->table->start_hour,
                             'inline' => true,
                         ],
-                    ],
-                    'footer' => [
-                        'text' => $this->discordNotificationData->table->description,
+                        [
+                            'name' => 'Description',
+                            'value' => $this->discordNotificationData->table->description,
+                            'inline' => false,
+                        ],
+                        [
+                            'name' => 'Lien Inscription',
+                            'value' => '[Cliquez ici]('.$this->setExternalLink($this->discordNotificationData).')',
+                            'inline' => false,
+                        ],
                     ],
                 ],
             ],
@@ -45,9 +42,9 @@ class UpdateTableNotification extends DiscordNotification
         return $this;
     }
 
-    private static function setEmbedDescription(int $dayId): string
+    private static function setExternalLink(DiscordNotificationData $discordNotificationData): string
     {
-        return 'Plus d\'informations sur '.config('app.url').'/days/'.$dayId;
+        return config('app.url').'/days/'.$discordNotificationData->day->id;
     }
 
     public function send(): void


### PR DESCRIPTION
# Description

Improve the content text of some discord notifications.

## Motivation of this modifications

It will be useful for the users to know the game category when a new table is created.
That's why the game category will be integrated into the main discord message title.

The second reason is to improve the readability of the discord notifications by modifiyng the content.

## Screenshots

New content design proposed
![image](https://github.com/user-attachments/assets/fd9e4061-9cce-425c-b5ca-5797bfa51715)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [x] This change requires a documentation update

# Unit or Feature tests ?

N/A

# Action to make within this PR
- [x] Improve the content of the TableCreatedDiscordNotification
- [x] Improve the content of the TableUpdatedDiscordNotification

# Actions checklist before merge (remove non relevant options):
- [x] Execute the code styles LINT command
- [x] Execute the static analysis tool (PHPStan for example)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The feature test suite passes with my changes
- [x] The unit test suite passes with my changes
- [x] User Documentation update

# Actions checklist after merge and CD (remove non relevant options):

N/A
