### PR TITLE
Fixed an user could susbscribe twice to the same table

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -123,8 +123,11 @@ class TableController extends Controller
         }
 
         if (app(UserLogic::class)->isAlreadySubscribedToATable($table)) {
-            return redirect()->route('days.show',
-                $table->day)->with(['error' => 'Vous êtes déjà inscrit à cette table']);
+            return redirect()
+                ->route('days.show', $table->day)
+                ->with([
+                    'error' => 'Vous êtes déjà inscrit à cette table',
+                ]);
         }
 
         $table->users()->attach(Auth::user());

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -122,6 +122,11 @@ class TableController extends Controller
             return redirect()->route('days.show', $table->day)->with(['error' => 'Vous êtes déjà inscrit à une autre table à la même heure ce jour là']);
         }
 
+        if (app(UserLogic::class)->isAlreadySubscribedToATable($table)) {
+            return redirect()->route('days.show',
+                $table->day)->with(['error' => 'Vous êtes déjà inscrit à cette table']);
+        }
+
         $table->users()->attach(Auth::user());
 
         $discordNotificationData = $this->discordNotificationData::make($table->game, $table, $table->day);

--- a/app/Logic/UserLogic.php
+++ b/app/Logic/UserLogic.php
@@ -5,6 +5,7 @@ namespace App\Logic;
 use App\Models\Day;
 use App\Models\Table;
 use Illuminate\Support\Facades\Auth;
+use Mockery\Exception;
 
 class UserLogic
 {
@@ -23,6 +24,19 @@ class UserLogic
             if ($table->users->contains(Auth::user())) {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    public function isAlreadySubscribedToATable(Table $table): bool
+    {
+        $user = Auth::user();
+
+        if ($table->users->contains(Auth::user()->id)) {
+            throw new Exception('user already subscribed to table');
+
+            return true;
         }
 
         return false;

--- a/app/Logic/UserLogic.php
+++ b/app/Logic/UserLogic.php
@@ -5,7 +5,6 @@ namespace App\Logic;
 use App\Models\Day;
 use App\Models\Table;
 use Illuminate\Support\Facades\Auth;
-use Mockery\Exception;
 
 class UserLogic
 {
@@ -34,8 +33,6 @@ class UserLogic
         $user = Auth::user();
 
         if ($table->users->contains(Auth::user()->id)) {
-            throw new Exception('user already subscribed to table');
-
             return true;
         }
 

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -41,7 +41,7 @@ class CreateTableNotification extends DiscordNotification
                         ],
                         [
                             'name' => 'Description',
-                            'value' => $this->discordNotificationData->table->description,
+                            'value' => $this->discordNotificationData->table->description ?? 'Aucune description fournie',
                             'inline' => false,
                         ],
                         [

--- a/tests/Feature/Http/Controllers/TableControllerTest.php
+++ b/tests/Feature/Http/Controllers/TableControllerTest.php
@@ -194,6 +194,19 @@ it('Can not subscribe a user already subscribed to another table with the same s
     expect($anotherTableAtSameHour->users->count())->toBe(0);
 });
 
+it('Can not subscribe a user twice or more for the same table', function () {
+    $day = createDay();
+    $table = createTable(day: $day, start_hour: '21:00');
+
+    app(UserSubscriptionAction::class)->execute($table, Auth::user());
+
+    $response = get(route('table.subscribe', $table));
+
+    expect($response)
+        ->toBeRedirect(route('days.show', $day))
+        ->toHaveSession('error');
+});
+
 test('A user can not see the edit action button for a table he didnt created', function () {
     $day = createDay();
 


### PR DESCRIPTION
# Description

We have to block the possibilty for a user to subscribed twice or more on the same table.
If an user try to subscribe a to a table if he is already subscribed he will receive an error

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [ ] This change requires a documentation update

# Unit or Feature tests

Describe the tests that are added or modified within this pull request.

- [x] NEW - The user can not subscribed twice on the same table

# Actions checklist before merge (remove non relevant options):

- [x] Execute the code styles LINT command
- [x] Execute the static analysis tool (PHPStan for example)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The feature test suite passes with my changes
- [x] The unit test suite passes with my changes