### PR TITLE
Edit main discord message when a table is updated

### DIFF
--- a/app/DataObjects/DiscordNotificationData.php
+++ b/app/DataObjects/DiscordNotificationData.php
@@ -32,4 +32,29 @@ class DiscordNotificationData
             extra: $extra,
         );
     }
+
+    public function gameName(): string
+    {
+        return $this->game->name;
+    }
+
+    public function getCategory()
+    {
+        return $this->game->category->name;
+    }
+
+    public function getDay()
+    {
+        return $this->day->date->format('d/m/Y');
+    }
+
+    public function getStartHour(): string
+    {
+        return $this->table->start_hour;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->table->description;
+    }
 }

--- a/app/DataObjects/DiscordNotificationData.php
+++ b/app/DataObjects/DiscordNotificationData.php
@@ -38,12 +38,12 @@ class DiscordNotificationData
         return $this->game->name;
     }
 
-    public function getCategory()
+    public function getCategory(): string
     {
         return $this->game->category->name;
     }
 
-    public function getDay()
+    public function getDay(): string
     {
         return $this->day->date->format('d/m/Y');
     }

--- a/app/Enums/EmbedColor.php
+++ b/app/Enums/EmbedColor.php
@@ -6,5 +6,5 @@ enum EmbedColor: int
 {
     case CREATED = 65280;
     case DELETED = 16711680;
-    case WARNING = 16711650;
+    case WARNING = 16753920;
 }

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -100,8 +100,12 @@ class TableController extends Controller
 
             $discordNotificationData = $this->discordNotificationData::make($table->game, $table, $table->day);
 
-            $discordNotification = ($this->notificationFactory)(entity: 'table', type: 'update-table',
-                discordNotificationData: $discordNotificationData);
+            $discordNotification = ($this->notificationFactory)(
+                entity: 'table',
+                type: 'update-table',
+                discordNotificationData: $discordNotificationData
+            );
+
             $discordNotification->handle();
 
         } catch (Exception $e) {

--- a/app/Logic/TableLogic.php
+++ b/app/Logic/TableLogic.php
@@ -30,4 +30,11 @@ class TableLogic
 
         $table->save();
     }
+
+    public static function saveMessageId(int $messageId, Table $table): void
+    {
+        $table->discord_message_id = $messageId;
+
+        $table->save();
+    }
 }

--- a/app/Notifications/Discord/Event/CancelEventNotification.php
+++ b/app/Notifications/Discord/Event/CancelEventNotification.php
@@ -34,7 +34,7 @@ class CancelEventNotification extends DiscordNotification
     {
         $eventAttributes = $discordNotificationData->extra;
 
-        return 'L\'évènement '.$eventAttributes['name'].' prévue le '.$discordNotificationData->day->date->format('d/m/Y').' à '.$eventAttributes['start_hour'].' est annulé.';
+        return 'L\'évènement '.$eventAttributes['name'].' prévue le '.$discordNotificationData->getDay().' à '.$eventAttributes['start_hour'].' est annulé.';
     }
 
     public function send(): void

--- a/app/Notifications/Discord/Event/CreateEventNotification.php
+++ b/app/Notifications/Discord/Event/CreateEventNotification.php
@@ -28,7 +28,7 @@ class CreateEventNotification extends DiscordNotification
                     'fields' => [
                         [
                             'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
+                            'value' => $this->discordNotificationData->getDay(),
                             'inline' => true,
                         ],
                         [

--- a/app/Notifications/Discord/Event/UpdateEventNotification.php
+++ b/app/Notifications/Discord/Event/UpdateEventNotification.php
@@ -27,7 +27,7 @@ class UpdateEventNotification extends DiscordNotification
                     'fields' => [
                         [
                             'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
+                            'value' => $this->discordNotificationData->getDay(),
                             'inline' => true,
                         ],
                         [

--- a/app/Notifications/Discord/Strategies/CreateMessageAndThread.php
+++ b/app/Notifications/Discord/Strategies/CreateMessageAndThread.php
@@ -28,6 +28,8 @@ class CreateMessageAndThread implements MessageCreationStrategy
     {
         $messageId = $this->sendMessage($channelId, $embedMessage);
 
+        $this->saveMessageIdOnTable($messageId, $table);
+
         $threadId = $this->createThread($channelId, $messageId);
 
         return $this->saveThreadIdOnTable($threadId, $table);
@@ -81,6 +83,11 @@ class CreateMessageAndThread implements MessageCreationStrategy
         $responseData = json_decode($response->getBody(), true);
 
         return (int) $responseData['id'];
+    }
+
+    private function saveMessageIdOnTable(int $messageId, Table $table): void
+    {
+        TableLogic::saveThreadId($messageId, $table);
     }
 
     private function saveThreadIdOnTable(int $threadId, Table $table): string

--- a/app/Notifications/Discord/Strategies/CreateMessageAndThread.php
+++ b/app/Notifications/Discord/Strategies/CreateMessageAndThread.php
@@ -87,7 +87,7 @@ class CreateMessageAndThread implements MessageCreationStrategy
 
     private function saveMessageIdOnTable(int $messageId, Table $table): void
     {
-        TableLogic::saveThreadId($messageId, $table);
+        TableLogic::saveMessageId($messageId, $table);
     }
 
     private function saveThreadIdOnTable(int $threadId, Table $table): string

--- a/app/Notifications/Discord/Strategies/UpdateMessage.php
+++ b/app/Notifications/Discord/Strategies/UpdateMessage.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications\Discord\Strategies;
+
+use App\Contracts\MessageCreationStrategy;
+use App\Models\Table;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class UpdateMessage implements MessageCreationStrategy
+{
+    public function __construct(
+        private Client $client
+    ) {
+        //
+    }
+
+    public function handle(int $channelId, array $embedMessage, ?Table $table): string
+    {
+        try {
+            $this->client->patch(config('discord.api_url').$channelId.'/messages/'.$table->discord_message_id, [
+                'headers' => $this->getHeaders(),
+                'json' => $embedMessage,
+            ]);
+
+            return 'Discord notification updated';
+        } catch (GuzzleException $e) {
+            throw new \Exception($e->getMessage());
+        }
+    }
+
+    private function getHeaders(): array
+    {
+        return [
+            'Authorization' => config('discord.bot_token'),
+            'Content-Type' => 'application/json',
+        ];
+    }
+}

--- a/app/Notifications/Discord/Table/CreateTableNotification.php
+++ b/app/Notifications/Discord/Table/CreateTableNotification.php
@@ -21,27 +21,27 @@ class CreateTableNotification extends DiscordNotification
                     'author' => [
                         'name' => 'Organisateur : '.Auth::user()->name,
                     ],
-                    'title' => 'Jeu proposé : '.$this->discordNotificationData->game->name,
+                    'title' => 'Jeu proposé : '.$this->discordNotificationData->gameName(),
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
                         [
                             'name' => 'Catégorie',
-                            'value' => $this->discordNotificationData->game->category->name,
+                            'value' => $this->discordNotificationData->getCategory(),
                             'inline' => false,
                         ],
                         [
                             'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
+                            'value' => $this->discordNotificationData->getDay(),
                             'inline' => true,
                         ],
                         [
                             'name' => 'Heure',
-                            'value' => $this->discordNotificationData->table->start_hour,
+                            'value' => $this->discordNotificationData->getStartHour(),
                             'inline' => true,
                         ],
                         [
                             'name' => 'Description',
-                            'value' => $this->discordNotificationData->table->description ?? 'Aucune description fournie',
+                            'value' => $this->discordNotificationData->getDescription() ?? 'Aucune description fournie',
                             'inline' => false,
                         ],
                         [

--- a/app/Notifications/Discord/Table/UpdateTableNotification.php
+++ b/app/Notifications/Discord/Table/UpdateTableNotification.php
@@ -16,7 +16,7 @@ class UpdateTableNotification extends DiscordNotification
     public function buildMessage(): self
     {
         $this->message = [
-            'content' => '@everyone '.EmbedMessageContent::UPDATED->value,
+            'content' => EmbedMessageContent::UPDATED->value,
             'embeds' => [
                 [
                     'author' => [

--- a/app/Notifications/Discord/Table/UpdateTableNotification.php
+++ b/app/Notifications/Discord/Table/UpdateTableNotification.php
@@ -86,13 +86,13 @@ class UpdateTableNotification extends DiscordNotification
         );
     }
 
-    private function createUpdateMessage(): void
+    public function createUpdateMessage(): void
     {
         $this->message = [
             'content' => EmbedMessageContent::UPDATED->value,
             'embeds' => [
                 [
-                    'title' => '⚠️ Table de '.$this->discordNotificationData->table->game->name.' mise à jour par '.auth::user()->name,
+                    'title' => '⚠️ Table de '.$this->discordNotificationData->table->game->name.' prévue le '.$this->discordNotificationData->day->date->format('d/m/Y').' a été mise à jour',
                     'color' => EmbedColor::WARNING->value,
                 ],
             ],

--- a/app/Notifications/Discord/Table/UpdateTableNotification.php
+++ b/app/Notifications/Discord/Table/UpdateTableNotification.php
@@ -22,27 +22,27 @@ class UpdateTableNotification extends DiscordNotification
                     'author' => [
                         'name' => 'Organisateur : '.Auth::user()->name,
                     ],
-                    'title' => 'Jeu proposé : '.$this->discordNotificationData->game->name,
+                    'title' => 'Jeu proposé : '.$this->discordNotificationData->gameName(),
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
                         [
                             'name' => 'Catégorie',
-                            'value' => $this->discordNotificationData->game->category->name,
+                            'value' => $this->discordNotificationData->getCategory(),
                             'inline' => false,
                         ],
                         [
                             'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
+                            'value' => $this->discordNotificationData->getDay(),
                             'inline' => true,
                         ],
                         [
                             'name' => 'Heure',
-                            'value' => $this->discordNotificationData->table->start_hour,
+                            'value' => $this->discordNotificationData->getStartHour(),
                             'inline' => true,
                         ],
                         [
                             'name' => 'Description',
-                            'value' => $this->discordNotificationData->table->description ?? 'Aucune description fournie',
+                            'value' => $this->discordNotificationData->getDescription() ?? 'Aucune description fournie',
                             'inline' => false,
                         ],
                         [

--- a/app/Notifications/Discord/Table/UpdateTableNotification.php
+++ b/app/Notifications/Discord/Table/UpdateTableNotification.php
@@ -92,7 +92,7 @@ class UpdateTableNotification extends DiscordNotification
             'content' => EmbedMessageContent::UPDATED->value,
             'embeds' => [
                 [
-                    'title' => '⚠️ Table de '.$this->discordNotificationData->table->game->name.' prévue le '.$this->discordNotificationData->day->date->format('d/m/Y').' a été mise à jour',
+                    'title' => '⚠️ La table de '.$this->discordNotificationData->gameName().' du '.$this->discordNotificationData->getDay().' a été mise à jour',
                     'color' => EmbedColor::WARNING->value,
                 ],
             ],

--- a/app/Notifications/Discord/User/UserSubscriptionNotification.php
+++ b/app/Notifications/Discord/User/UserSubscriptionNotification.php
@@ -17,17 +17,17 @@ class UserSubscriptionNotification extends DiscordNotification
             'content' => EmbedMessageContent::SUBSCRIBED->value,
             'embeds' => [
                 [
-                    'title' => Auth::user()->name.' s\'est inscrit à la table de '.$this->discordNotificationData->game->name,
+                    'title' => Auth::user()->name.' s\'est inscrit à la table de '.$this->discordNotificationData->gameName(),
                     'color' => EmbedColor::CREATED->value,
                     'fields' => [
                         [
                             'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
+                            'value' => $this->discordNotificationData->getDay(),
                             'inline' => true,
                         ],
                         [
                             'name' => 'Heure',
-                            'value' => $this->discordNotificationData->table->start_hour,
+                            'value' => $this->discordNotificationData->getStartHour(),
                             'inline' => true,
                         ],
                     ],

--- a/app/Notifications/Discord/User/UserUnsubscriptionNotification.php
+++ b/app/Notifications/Discord/User/UserUnsubscriptionNotification.php
@@ -22,12 +22,12 @@ class UserUnsubscriptionNotification extends DiscordNotification
                     'fields' => [
                         [
                             'name' => 'Date',
-                            'value' => $this->discordNotificationData->day->date->format('d/m/Y'),
+                            'value' => $this->discordNotificationData->getDay(),
                             'inline' => true,
                         ],
                         [
                             'name' => 'Heure',
-                            'value' => $this->discordNotificationData->table->start_hour,
+                            'value' => $this->discordNotificationData->getStartHour(),
                             'inline' => true,
                         ],
                     ],

--- a/database/migrations/2024_10_16_122127_add_discord_message_id_into_tables_table.php
+++ b/database/migrations/2024_10_16_122127_add_discord_message_id_into_tables_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table
+                ->bigInteger('discord_message_id')
+                ->unsigned()
+                ->after('start_hour')
+                ->nullable();
+        });
+    }
+};

--- a/tests/Feature/Notifications/CreateTableNotificationTest.php
+++ b/tests/Feature/Notifications/CreateTableNotificationTest.php
@@ -28,3 +28,26 @@ test('The discord thread id is stored into new created table', function () {
 
     expect($createdTable->discord_thread_id)->toBe(123456789);
 });
+
+test('The discord message id is stored into table informations', function () {
+    login();
+    mockCreateMessageAndThreadStrategy();
+
+    $day = createDay();
+    $game = createGameWithCategory();
+
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('21:00')
+        ->create();
+
+    post(route('table.store', $day), $tableAttributes);
+
+    $createdTable = Table::first();
+
+    expect($createdTable->discord_message_id)->toBe(23456789);
+});

--- a/tests/Feature/Notifications/UpdateTableNotificationTest.php
+++ b/tests/Feature/Notifications/UpdateTableNotificationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Notifications\Discord\Table\UpdateTableNotification;
+use Illuminate\Support\Facades\Auth;
+use Tests\RequestFactories\TableRequestFactory;
+
+use function Pest\Laravel\patch;
+
+test('UpdateTableNotification updates the main discord message and send a update notification message', function () {
+    login();
+    mockHttpClient();
+
+    $client = Mockery::mock(UpdateTableNotification::class);
+    $client->shouldReceive('defineChannelId');
+    $client->shouldReceive('buildMessage');
+    $client->shouldReceive('send');
+    $client->shouldReceive('createUpdateMessage');
+
+    $day = createDay();
+    $table = createTable();
+
+    $game = createGameWithCategory();
+
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('21:00')
+        ->create();
+
+    $response = patch(route('table.update', $table), $tableAttributes);
+
+    expect($response->status())->toBe(302);
+});

--- a/tests/Mocks/CreateMessageAndThreadFake.php
+++ b/tests/Mocks/CreateMessageAndThreadFake.php
@@ -17,9 +17,17 @@ class CreateMessageAndThreadFake implements MessageCreationStrategy
      */
     public function handle(int $channelId, array $embedMessage, ?Table $table): string
     {
+        $messageId = $this->createMessage();
         $threadId = $this->createThread();
 
+        $this->saveMessageIdOnTable($messageId, $table);
+
         return $this->saveThreadIdOnTable($threadId, $table);
+    }
+
+    public function createMessage(): int
+    {
+        return 23456789;
     }
 
     public function createThread(): int
@@ -32,5 +40,10 @@ class CreateMessageAndThreadFake implements MessageCreationStrategy
         TableLogic::saveThreadId($threadId, $table);
 
         return 'Discord notification and thread created';
+    }
+
+    private function saveMessageIdOnTable(int $messageId, Table $table): void
+    {
+        TableLogic::saveMessageId($messageId, $table);
     }
 }


### PR DESCRIPTION
# Description

We want to update the main discord message when a user has updated the table informations.
Besides a little notification about the updated table will be sent too to inform every users, and send a push notification to ensure that the information will be see by the users.

## Motivation of these modifications

Actually, there is a notification included into the discord thread that informs of the table update.
However, the main discord message is not updated and could give some confusion to the users.

With this feature, the users will not have confusion due to incorrect informations.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [x] This change requires a documentation update

# Unit or Feature tests ?

The following tests are added or modified within this pull request.

- [x] The discord message id is stored into table informations

# Actions checklist before merge (remove non relevant options):

- [x] Execute the code styles LINT command
- [x] Execute the static analysis tool (PHPStan for example)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The feature test suite passes with my changes
- [x] The unit test suite passes with my changes
- [x] User Documentation update

# Actions checklist after merge and CD (remove non relevant options):

- N/A