### PR TITLE
Added day full name into the day show view

### DIFF
--- a/resources/views/day/show.blade.php
+++ b/resources/views/day/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header" class="flex flex-row justify-between">
         <h2 class="font-bold text-xl text-gray-800 text-center dark:text-gray-200 leading-tight lg:text-2xl">
-            Session du {{ $day->date->format('d/m/Y') }}
+            Session du {{ $day->fullDayName }} {{ $day->date->format('d/m/Y') }}
         </h2>
         @if($day->explanation !== null)
             <div class="mt-4 flex justify-center items-center gap-x-4 bg-red-500 rounded-lg text-white text-center">


### PR DESCRIPTION
# Description

Actually, into the day show page, there is only the raw date displayed.

## Motivation of this modifications
Allow the users to know the exact day name of a game session

## Screenshots

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [ ] This change requires a documentation update

# Unit or Feature tests ?

N/A

# Actions checklist before merge (remove non relevant options):

- [x] Execute the code styles LINT command
- [x] Execute the static analysis tool (PHPStan for example)
- [x] The feature test suite passes with my changes
- [x] The unit test suite passes with my changes

# Actions checklist after merge and CD (remove non relevant options):

N/A