### PR TITLE
Manage games and categories by association

### DIFF
--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\GameResource\Pages;
 use App\Models\Category;
 use App\Models\Game;
+use App\Storages\AssociationStorage;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -23,11 +24,13 @@ class GameResource extends Resource
 
     public static function form(Form $form): Form
     {
+        $currentAssociationId = AssociationStorage::current()->id;
+
         return $form
             ->schema([
                 Forms\Components\Select::make('category_id')
                     ->label('Category')
-                    ->options(Category::all()->pluck('name', 'id'))
+                    ->options(Category::query()->where('association_id', $currentAssociationId)->pluck('name', 'id'))
                     ->label('Catégorie'),
                 Forms\Components\TextInput::make('name')
                     ->required()

--- a/app/Filament/Resources/GameResource/Pages/ListGames.php
+++ b/app/Filament/Resources/GameResource/Pages/ListGames.php
@@ -23,7 +23,10 @@ class ListGames extends ListRecords
 
     public function getTabs(): array
     {
-        $categories = Category::query()->where('association_id', AssociationStorage::current()->id)->get()->toArray();
+        $categories = Category::query()
+            ->where('association_id', AssociationStorage::current()->id)
+            ->get()
+            ->toArray();
 
         foreach ($categories as $category) {
             $types[$category['name']] = Tab::make()

--- a/app/Filament/Resources/GameResource/Pages/ListGames.php
+++ b/app/Filament/Resources/GameResource/Pages/ListGames.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Resources\GameResource\Pages;
 
 use App\Filament\Resources\GameResource;
+use App\Models\Category;
+use App\Storages\AssociationStorage;
 use Filament\Actions;
 use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
@@ -21,16 +23,13 @@ class ListGames extends ListRecords
 
     public function getTabs(): array
     {
-        return [
-            'Tout types' => Tab::make(),
-            'Cartes' => Tab::make()
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('category_id', 1)),
-            'Plateau' => Tab::make()
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('category_id', 2)),
-            'Rôles' => Tab::make()
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('category_id', 3)),
-            'Wargame' => Tab::make()
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('category_id', 4)),
-        ];
+        $categories = Category::query()->where('association_id', AssociationStorage::current()->id)->get()->toArray();
+
+        foreach ($categories as $category) {
+            $types[$category['name']] = Tab::make()
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('category_id', $category['id']));
+        }
+
+        return $types;
     }
 }

--- a/app/Http/Controllers/Day/DayController.php
+++ b/app/Http/Controllers/Day/DayController.php
@@ -38,7 +38,9 @@ class DayController extends Controller
 
     public function create(Request $request): View
     {
-        return view('day.create');
+        $currentAssociation = AssociationStorage::current()->id;
+
+        return view('day.create', compact('currentAssociation'));
     }
 
     public function show(Day $day): View

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -14,6 +14,7 @@ use App\Models\Day;
 use App\Models\Game;
 use App\Models\Table;
 use App\Notifications\Discord\NotificationFactory;
+use App\Repositories\CategoryRepository;
 use App\Repositories\GameRepository;
 use Exception;
 use Illuminate\Http\RedirectResponse;
@@ -29,6 +30,7 @@ class TableController extends Controller
         public CreateTableHandler $createTableHandler,
         public UpdateTableHandler $updateTableHandler,
         public GameRepository $gameRepository,
+        public CategoryRepository $categoryRepository,
     ) {
         //
     }
@@ -39,7 +41,7 @@ class TableController extends Controller
             abort(403);
         }
 
-        $categories = Category::all();
+        $categories = $this->categoryRepository->allForCurrentAssociation();
 
         return view('table.create', compact('day', 'categories'));
     }

--- a/app/Http/Requests/storeDayRequest.php
+++ b/app/Http/Requests/storeDayRequest.php
@@ -25,7 +25,6 @@ class storeDayRequest extends FormRequest
     {
         return [
             'date' => 'required|date|unique:days,date',
-            'association_id' => 'required|exists:associations,id',
         ];
     }
 

--- a/app/Models/Association.php
+++ b/app/Models/Association.php
@@ -30,8 +30,8 @@ class Association extends Model
     /**
      * @phpstan-ignore-next-line
      */
-    public function categories(): BelongsToMany
+    public function categories(): HasMany
     {
-        return $this->belongsToMany(Category::class);
+        return $this->hasMany(Category::class);
     }
 }

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 class CategoryRepository
 {
+    // @phpstan-ignore-next-line
     public function allForCurrentAssociation(): ?Collection
     {
         $association = AssociationStorage::current();

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Storages\AssociationStorage;
+use Illuminate\Database\Eloquent\Collection;
+
+class CategoryRepository
+{
+    public function allForCurrentAssociation(): ?Collection
+    {
+        $association = AssociationStorage::current();
+
+        return $association->categories;
+    }
+}

--- a/tests/Feature/Http/Controllers/DayControllerTest.php
+++ b/tests/Feature/Http/Controllers/DayControllerTest.php
@@ -217,4 +217,14 @@ test('The create buttons are hidden for a cancelled day', function () {
     get(route('days.show', $day))
         ->assertDontSee('img/game-table.png')
         ->assertDontSee('img/calendar.png');
+
+});
+
+test('The user can not see the days of another association', function () {
+    $anotherAssociation = createAssociation();
+    $dayForAnotherAssociation = createDayForAssociation($anotherAssociation);
+
+    $response = get(route('days.index'));
+
+    expect($response)->assertDontSee("days/$dayForAnotherAssociation->id");
 });

--- a/tests/Feature/Http/Controllers/TableControllerTest.php
+++ b/tests/Feature/Http/Controllers/TableControllerTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use App\Models\Association;
 use App\Models\Category;
 use App\Models\Day;
 use App\Models\Game;
 use App\Models\Table;
+use App\Storages\AssociationStorage;
 use Illuminate\Support\Facades\Auth;
 use Tests\RequestFactories\TableRequestFactory;
 
@@ -18,7 +20,10 @@ beforeEach(function () {
 });
 
 it('Display all game categories in the create view form', function () {
-    $day = createDay();
+    $association = Association::factory()->create();
+    AssociationStorage::put($association);
+
+    $day = createDayForAssociation(AssociationStorage::current(), now());
     $category = Category::factory()->create();
 
     $response = get(route('table.create', $day));

--- a/tests/Feature/Http/Controllers/TableControllerTest.php
+++ b/tests/Feature/Http/Controllers/TableControllerTest.php
@@ -19,7 +19,7 @@ beforeEach(function () {
     login();
 });
 
-it('Display all game categories in the create view form', function () {
+it('Display the game categories of the current association in the create view form', function () {
     $association = Association::factory()->create();
     AssociationStorage::put($association);
 
@@ -31,6 +31,24 @@ it('Display all game categories in the create view form', function () {
     $response->assertOk();
 
     $response->assertSee($category->name);
+});
+
+it('Do not Display the game categories of another association in the create view form', function () {
+    $association = Association::factory()->create();
+    AssociationStorage::put($association);
+
+    $day = createDayForAssociation(AssociationStorage::current(), now());
+    $category = Category::factory()->create();
+
+    // Create another category for another Association
+    $anotherAssociation = Association::factory()->create();
+    $anotherCategory = Category::factory()->create([
+        'association_id' => $anotherAssociation->id,
+    ]);
+
+    $response = get(route('table.create', $day));
+    $response->assertSee($category->name);
+    $response->assertDontSee($anotherCategory->name);
 });
 
 it('Creates a new table', function () {


### PR DESCRIPTION
# Description

Fetch Games and Categories according to the current Association of the User

## Motivation of these modifications

An User from a specific Association must see only the Games and Categories of his Association.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [ ] This change requires a documentation update

# Unit or Feature tests

- [x] (Add) Day - A user can see only the days of his association
- [x] (Add) Categories - A user can only see game categories from his association into the table create page

# Actions checklist before merge (remove non relevant options):

- [x] Execute the code styles LINT command
- [x] Execute the static analysis tool (PHPStan for example)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The feature test suite passes with my changes
- [x] The unit test suite passes with my changes