### PR TITLE
Add current user id to check for tables duplicates

### DIFF
--- a/app/Handlers/CreateTableHandler.php
+++ b/app/Handlers/CreateTableHandler.php
@@ -34,8 +34,8 @@ class CreateTableHandler
 
     private function checkIfTableExists(TableData $tableAttributes): void
     {
-        if (TableLogic::isAlreadyExists($tableAttributes)) {
-            throw new Exception('Vous ne pouvez pas créer 2 fois la même table');
+        if (TableLogic::isAlreadyExists($tableAttributes)) {            
+            throw new Exception('Vous ne pouvez pas créer 2 fois la même table, le même jour');
         }
     }
 

--- a/app/Logic/TableLogic.php
+++ b/app/Logic/TableLogic.php
@@ -5,12 +5,16 @@ namespace App\Logic;
 use App\DataObjects\TableData;
 use App\Models\Day;
 use App\Models\Table;
+use Illuminate\Support\Facades\Auth;
 
 class TableLogic
 {
     public static function isAlreadyExists(TableData $tableAttributes): bool
     {
+        $user = Auth::user();
+
         $table = Table::query()
+            ->where('organizer_id', $user->id)
             ->where('game_id', $tableAttributes->game_id)
             ->where('day_id', $tableAttributes->day_id)
             ->where('start_hour', $tableAttributes->start_hour)

--- a/tests/Feature/Http/Controllers/TableControllerTest.php
+++ b/tests/Feature/Http/Controllers/TableControllerTest.php
@@ -132,6 +132,45 @@ it('Can not create the same table twice', function () {
         ->toHaveSession('error');
 });
 
+
+it('Can create the same table as another user for the same game for the same day', function () {
+    login();
+    $day = createDay();
+    $game = createGameWithCategory();
+    mockHttpClient();
+
+    $tableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('21:00')
+        ->create();
+
+    // Create a new table
+    post(route('table.store', $day), $tableAttributes);
+    
+    login();
+
+    $sameTableAttributes = TableRequestFactory::new()
+        ->withOrganizer(Auth::user())
+        ->withDay($day)
+        ->withGame($game)
+        ->withCategory($game->category)
+        ->withPlayersNumber(5)
+        ->withStartHour('21:00')
+        ->create();
+
+    // Try to create the same table twice
+    $response = post(route('table.store', $day), $tableAttributes);
+
+    expect($response)
+        ->toBeRedirect(route('days.show', $day))
+        ->and(Table::count())->toBe(2);
+});
+
+
 it('Updates a table', function () {
     login();
     mockHttpClient();


### PR DESCRIPTION
# Description

The check logic for tables duplication does not include the current user id.
If 2 different users try to create the same table for the same day at the same hour an error is thrown.

## Motivation of these modifications

Add the current user id into the check of duplicates logic.

## Screenshots

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature with Breaking change (feature that cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactorization (Code improvement without changing code behavior)
- [ ] This change requires a documentation update

# Unit or Feature tests ?

Describe the tests that are added or modified within this pull request.

- [x] Can create the same table as another user for the same game for the same day

# Actions checklist before merge (remove non relevant options):

- [x] The feature test suite passes with my changes
- [x] The unit test suite passes with my changes